### PR TITLE
Make Overlay state obvious; limit Sandbox actions in Overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         { "command": "sandbox.stop", "when": "view == sandboxExplorer", "group": "navigation@3" },
         { "command": "sandbox.delete", "when": "view == sandboxExplorer", "group": "navigation@4" },
         { "command": "sandbox.showConfig", "when": "view == sandboxExplorer", "group": "navigation@5" },
-        { "command": "sandbox.useOverlayInExplorer", "when": "view == sandboxExplorer", "group": "navigation@6" },
+        { "command": "sandbox.useOverlayInExplorer", "when": "view == sandboxExplorer && !sandbox.inOverlayRoot", "group": "navigation@6" },
         { "command": "sandbox.restoreWorkspaceFolder", "when": "view == sandboxExplorer && sandbox.hasOriginal", "group": "navigation@7" }
       ],
       "view/item/context": [


### PR DESCRIPTION
## Summary
- Add a clear, persistent indicator in the Sandbox view when the Explorer is showing the Overlay.
- Limit the Sandbox Actions list to only "Enter Sandbox" and "Restore Workspace Folder" while in Overlay (restore shown only if a recorded original exists).
- Align the view toolbar to hide "Use Overlay in Explorer" when already in overlay; keep "Restore Workspace Folder" gated by context.

## Details
- UI contexts: `sandbox.inOverlayRoot` and `sandbox.hasOriginal` are set via `setContext` and kept in sync on activation, after root-affecting commands, and on workspace folder changes.
- Tree provider reads these flags to:
  - Render an indicator node (label: "Overlay active", tooltip explaining how to exit; with accessible label)
  - Conditionally render a reduced Actions list in overlay
- Toolbar when-clauses updated in `package.json` to match contexts.

## Files changed
- `src/extension.ts`: overlay detection + context updates; wiring updates on relevant events
- `src/tree.ts`: indicator node and conditional Actions rendering; accepts UI context flags
- `package.json`: toolbar when-clause for `sandbox.useOverlayInExplorer`

## Validation
Please verify the following (screenshots/gifs attached):
1) Normal workspace (not overlay):
   - Actions show full set.
   - Toolbar shows "Use Overlay in Explorer"; "Restore Workspace Folder" hidden.
2) After "Use Overlay in Explorer":
   - "Overlay active" indicator appears at top of Sandbox view.
   - Actions show only "Enter Sandbox" and (if mapping exists) "Restore Workspace Folder".
   - Toolbar hides "Use Overlay in Explorer" and shows "Restore Workspace Folder" when mapping exists.
3) Manually opening an overlay path (no mapping):
   - Indicator appears.
   - Actions only show "Enter Sandbox".

## Screenshots / GIFs
- [ ] Normal workspace — full actions
- [ ] Overlay active — indicator visible, actions filtered
- [ ] Overlay without mapping — indicator visible, restore hidden

## Accessibility
- Indicator includes an accessible label and tooltip.

Fixes #2